### PR TITLE
Do not add item if it would link to empty page

### DIFF
--- a/src/utils/getPagination.js
+++ b/src/utils/getPagination.js
@@ -9,13 +9,15 @@ const getPagination = (props) => {
     let max = props.showMax > props.totalPages ? props.totalPages : props.showMax;
 
     for (let i = 0; i < max; i++) {
-        arr.push({
-            page: startAt + i,
-            text: startAt + i,
-            isCurrent: isCurrent(startAt + i, props.currentPage),
-            class: isCurrent(startAt + i, props.currentPage) ? props.activeClass : props.defaultClass,
-            href: startAt + i === 1 ? props.href && props.pageOneHref : props.href && props.href.replace('*', startAt + i)
-        });
+        if (!(startAt + i > props.totalPages)) {
+            arr.push({
+                page: startAt + i,
+                text: startAt + i,
+                isCurrent: isCurrent(startAt + i, props.currentPage),
+                class: isCurrent(startAt + i, props.currentPage) ? props.activeClass : props.defaultClass,
+                href: startAt + i === 1 ? props.href && props.pageOneHref : props.href && props.href.replace('*', startAt + i)
+            });
+        }
     }
 
     if (props.threeDots) {


### PR DESCRIPTION
Currently, getPagination will render links to pages
outside the range of `props.maxPages`. However,
the next/prev toggles will correctly disable
themselves in this case.

This change more or less copies the logic from 
addNext to fix this bug. Perhaps there is a
more elegant solution?

Co-authored-by: Josh Couper <joshcouper@gmail.com>